### PR TITLE
Fix evm substrate address converter not using PLM prefix

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ function App() {
       addressType === "EVM" &&
       polkadotCryptoUtils.isEthereumChecksum(addressInput)
     ) {
-      return polkadotCryptoUtils.evmToAddress(addressInput);
+      return polkadotCryptoUtils.evmToAddress(addressInput, PLM_PREFIX);
     } else {
       return "invalid";
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ const PLM_PREFIX = 5;
 
 function App() {
   const [addressType, setAddressType] = useState<"EVM" | "PLM">("PLM");
-  const [addressInput, setAddressInput] = useState<string>();
+  const [addressInput, setAddressInput] = useState<string>("");
   const [addressPrefix, setAddressPrefix] = useState(PLM_PREFIX);
 
   const plmToEvm = useCallback(() => {


### PR DESCRIPTION
This is the warning that commit 1 fixes ![image](https://user-images.githubusercontent.com/17739166/121138301-20f5cb80-c86a-11eb-95e4-a674d27057b7.png)


