### PR TITLE
fixed bug where converting EVM to address always uses prefix of 5

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ function App() {
       addressType === "EVM" &&
       polkadotCryptoUtils.isEthereumChecksum(addressInput)
     ) {
-      return polkadotCryptoUtils.evmToAddress(addressInput, PLM_PREFIX);
+      return polkadotCryptoUtils.evmToAddress(addressInput, addressPrefix);
     } else {
       return "invalid";
     }


### PR DESCRIPTION
Sorry I used a constant instead of the variable lol. 